### PR TITLE
fixed the root of the overflow, the team list responsiveness

### DIFF
--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -49,7 +49,7 @@ export const TeamMember = ({ src, name }) => {
         <AiOutlineGithub fontSize="2rem" />
         <h2 className="pl-2 py-8 text-md xl:text-xl">Contributors:</h2>{" "}
       </div>
-      <ul className="grid grid-cols-6 gap-4 pl-4">
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-4 pl-4">
         {uniqueContributorsArray.map((contributor, index) => (
           <li key={index}>
             <a target="_blank" href={contributor.url}>


### PR DESCRIPTION

Fixed a visual bug causing a right-side overflow on smaller devices such as mobile. This was fixed at the root by making the Contributors List responsive 

Related to issue #11 

**Before**

![white-bar](https://github.com/CodeWithAloha/CWAWebsite/assets/42805189/b14a7e78-3aa5-4a8b-afdd-ad749d31fe7f)

![list-issue](https://github.com/CodeWithAloha/CWAWebsite/assets/42805189/6a6fd8cd-7fcb-41f7-8faf-fe6e028912d3)

**After**

![after-fix](https://github.com/CodeWithAloha/CWAWebsite/assets/42805189/fedec664-4c6e-48c8-a21a-50639c216473)

![after-fix-list](https://github.com/CodeWithAloha/CWAWebsite/assets/42805189/75df07b4-dc4b-4099-99dd-2da0d75bd8b9)
