### PR TITLE
feature: support all contributors

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -64,7 +64,7 @@ jobs:
             echo "Collecting contributors for $repository"
             curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc > $repository-contributors.json
 
-            if !jq -e . >/dev/null 2>&1 <<< "$(cat $repository-contributors.json)"; then
+            if ! jq -e . >/dev/null 2>&1 <<< "$(cat $repository-contributors.json)"; then
               echo "No contributors for $repository"
               continue
             fi

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -88,7 +88,7 @@ jobs:
 
           done
 
-          cat contributors.json          
+          cat contributors.json
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -66,10 +66,11 @@ jobs:
 
             if ! jq -e . >/dev/null 2>&1 <<< "$(cat $repository-contributors.json)"; then
               echo "No contributors for $repository"
+              rm $repository-contributors.json
               continue
             fi
 
-            echo $repository-contributors.json | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
+            cat $repository-contributors.json | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
             if [ -s $repository-contributors.json ]; then
               echo "Contributors found for $repository"
               cat $repository-contributors.json

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -72,20 +72,18 @@ jobs:
               continue
             fi
 
-            cat $repository-contributors.json | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
-            if [ -s $repository-contributors.json ]; then
-              echo "Contributors found for $repository"
-              cat $repository-contributors.json
+            cat $repository-contributors.json | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-output.json
+            
+            echo "Contributors found for $repository"
+            cat $repository-output.json
 
-              jq --argjson newContributors "$(cat $repository-contributors.json)" \
-              '.contributors["$repository"] |= (. + $newContributors) | 
-              .contributors["$repository"] |= unique_by(.username)' \
-              "contributors.json" > temp.json && mv temp.json "contributors.json"
+            jq --argjson newContributors "$(cat $repository-output.json)" \
+            '.contributors["$repository"] |= (. + $newContributors) | 
+            .contributors["$repository"] |= unique_by(.username)' \
+            "contributors.json" > temp.json && mv temp.json "contributors.json"
 
-              rm $repository-contributors.json
-            else
-              echo "No contributors for $repository"
-            fi
+            rm $repository-contributors.json
+            rm $repository-output.json
 
           done
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -64,8 +64,10 @@ jobs:
             echo "Collecting contributors for $repository"
             curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc > $repository-contributors.json
 
+            cat $repository-contributors.json
+
             if ! jq -e . >/dev/null 2>&1 <<< "$(cat $repository-contributors.json)"; then
-              echo "No contributors for $repository"
+              echo "No contributors for $repository, or .all-contributorsrc is not valid JSON"
               rm $repository-contributors.json
               continue
             fi

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -55,6 +55,31 @@ jobs:
           echo "}}" >> contributors.json
 
           cat contributors.json
+
+      - name: Collect all the contributors from allcontributors files
+        run: |
+          repositories=${{env.REPOSITORY_NAMES}}
+          for repository in ${repositories[@]}
+          do
+            echo "Collecting contributors for $repository"
+            curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
+            if [ -s $repository-contributors.json ]; then
+              echo "Contributors found for $repository"
+              cat $repository-contributors.json
+
+              jq --argjson newContributors "$(cat $repository-contributors.json)" \
+              '.contributors["$repository"] |= (. + $newContributors) | 
+              .contributors["$repository"] |= unique_by(.username)' \
+              "contributors.json" > temp.json && mv temp.json "contributors.json"
+
+              rm $repository-contributors.json
+            else
+              echo "No contributors for $repository"
+            fi
+
+          done
+
+          cat contributors.json          
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -64,7 +64,7 @@ jobs:
             echo "Collecting contributors for $repository"
             curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc > $repository-contributors.json
 
-            if !jq -e . >/dev/null 2>&1 < $repository-contributors.json; then
+            if !jq -e . >/dev/null 2>&1 <<< "$(cat $repository-contributors.json)"; then
               echo "No contributors for $repository"
               continue
             fi

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -62,7 +62,14 @@ jobs:
           for repository in ${repositories[@]}
           do
             echo "Collecting contributors for $repository"
-            curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
+            curl -s https://raw.githubusercontent.com/CodeWithAloha/$repository/main/.all-contributorsrc > $repository-contributors.json
+
+            if !jq -e . >/dev/null 2>&1 < $repository-contributors.json; then
+              echo "No contributors for $repository"
+              continue
+            fi
+
+            echo $repository-contributors.json | jq -r '.contributors[] | {username: .login, avatar_url: .avatar_url, url: .profile }' | jq -s . > $repository-contributors.json
             if [ -s $repository-contributors.json ]; then
               echo "Contributors found for $repository"
               cat $repository-contributors.json

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -78,8 +78,9 @@ jobs:
             cat $repository-output.json
 
             jq --argjson newContributors "$(cat $repository-output.json)" \
-            '.contributors["$repository"] |= (. + $newContributors) | 
-            .contributors["$repository"] |= unique_by(.username)' \
+              --arg repo "$repository" \
+            '.contributors[$repo] |= (. + $newContributors) | 
+            .contributors[$repo] |= unique_by(.username)' \
             "contributors.json" > temp.json && mv temp.json "contributors.json"
 
             rm $repository-contributors.json

--- a/contributors.json
+++ b/contributors.json
@@ -2,24 +2,14 @@
   "contributors": {
     "Hawaii-Zoning-Atlas": [
       {
-        "username": "kmal808",
-        "avatar_url": "https://avatars.githubusercontent.com/u/20919083?v=4",
-        "url": "https://github.com/kmal808"
+        "username": "Hooobot",
+        "avatar_url": "https://avatars.githubusercontent.com/u/73650949?v=4",
+        "url": "https://github.com/Hooobot"
       },
       {
-        "username": "tyliec",
-        "avatar_url": "https://avatars.githubusercontent.com/u/15609358?v=4",
-        "url": "https://github.com/tyliec"
-      },
-      {
-        "username": "avenmia",
-        "avatar_url": "https://avatars.githubusercontent.com/u/17712276?v=4",
-        "url": "https://github.com/avenmia"
-      },
-      {
-        "username": "operator130",
-        "avatar_url": "https://avatars.githubusercontent.com/u/105579826?v=4",
-        "url": "https://github.com/operator130"
+        "username": "MichelleShuey",
+        "avatar_url": "https://avatars.githubusercontent.com/u/120435891?v=4",
+        "url": "https://github.com/MichelleShuey"
       },
       {
         "username": "TyPushesButtons",
@@ -27,9 +17,14 @@
         "url": "https://github.com/TyPushesButtons"
       },
       {
-        "username": "Hooobot",
-        "avatar_url": "https://avatars.githubusercontent.com/u/73650949?v=4",
-        "url": "https://github.com/Hooobot"
+        "username": "airyclam",
+        "avatar_url": "https://avatars.githubusercontent.com/u/53859607?v=4",
+        "url": "https://github.com/airyclam"
+      },
+      {
+        "username": "avenmia",
+        "avatar_url": "https://avatars.githubusercontent.com/u/17712276?v=4",
+        "url": "https://github.com/avenmia"
       },
       {
         "username": "ggordn3r",
@@ -37,14 +32,9 @@
         "url": "https://github.com/ggordn3r"
       },
       {
-        "username": "yenhtran",
-        "avatar_url": "https://avatars.githubusercontent.com/u/7283964?v=4",
-        "url": "https://github.com/yenhtran"
-      },
-      {
-        "username": "airyclam",
-        "avatar_url": "https://avatars.githubusercontent.com/u/53859607?v=4",
-        "url": "https://github.com/airyclam"
+        "username": "jonathanswilcox",
+        "avatar_url": "https://avatars.githubusercontent.com/u/111539042?v=4",
+        "url": "https://github.com/jonathanswilcox"
       },
       {
         "username": "kcoronel",
@@ -52,9 +42,34 @@
         "url": "https://github.com/kcoronel"
       },
       {
+        "username": "kenz-bee",
+        "avatar_url": "https://avatars.githubusercontent.com/u/100083618?v=4",
+        "url": "https://github.com/kenz-bee"
+      },
+      {
+        "username": "kmal808",
+        "avatar_url": "https://avatars.githubusercontent.com/u/20919083?v=4",
+        "url": "https://github.com/kmal808"
+      },
+      {
         "username": "kobebuckley",
         "avatar_url": "https://avatars.githubusercontent.com/u/42805189?v=4",
         "url": "https://github.com/kobebuckley"
+      },
+      {
+        "username": "operator130",
+        "avatar_url": "https://avatars.githubusercontent.com/u/105579826?v=4",
+        "url": "https://github.com/operator130"
+      },
+      {
+        "username": "tyliec",
+        "avatar_url": "https://avatars.githubusercontent.com/u/15609358?v=4",
+        "url": "https://github.com/tyliec"
+      },
+      {
+        "username": "yenhtran",
+        "avatar_url": "https://avatars.githubusercontent.com/u/7283964?v=4",
+        "url": "https://github.com/yenhtran"
       }
     ],
     "HIERR": [
@@ -154,6 +169,11 @@
         "username": "Hooobot",
         "avatar_url": "https://avatars.githubusercontent.com/u/73650949?v=4",
         "url": "https://github.com/Hooobot"
+      },
+      {
+        "username": "kahookele",
+        "avatar_url": "https://avatars.githubusercontent.com/u/130222500?v=4",
+        "url": "https://github.com/kahookele"
       },
       {
         "username": "avenmia",


### PR DESCRIPTION
# Summary

Adds support for an `..all-contributorsrc` file in our repos to be added as contributors to the website.

Assumes we have one on the default branch (named `main`), and merges it with the GitHub API generated list of contributors/collaborators.

Test Run: https://github.com/CodeWithAloha/website/actions/runs/8035615585

## Changes

<!-- Please mark the line that applies with an x: [x] -->

- [ ] **Updated Section:** <!--(please specify which section) -->
- [ ] **Added new feature:** <!-- (please describe) -->
- [ ] **Fixed a bug:** <!-- (please describe) -->
- [ ] **Updated documentation**
